### PR TITLE
Added links to forGraphBLASGo and FalkorDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Version 1.1.0 (provisional) released on November 14, 2017.
 [Release Notes](https://www.mathworks.com/help/releases/R2021a/matlab/release-notes.html),
 under Performance.
 
+* [forGraphBLASGo - Go binding for SuiteSparse:GraphBLAS](https://pkg.go.dev/github.com/intel/forGraphBLASGo)
+
 * [pygraphblas Python library](https://github.com/Graphegon/pygraphblas)
 
 * [python-graphblas Python library](https://github.com/python-graphblas/python-graphblas)

--- a/README.md
+++ b/README.md
@@ -110,9 +110,7 @@ under Performance.
 
 # Graph analysis systems that integrate GraphBLAS
 
-* [RedisGraph: A Graph Database Module for
-  Redis](https://redislabs.com/redis-enterprise/redis-modules/redis-enterprise-modules/redisgraph/)
-
+* [FalkorDB - a queryable Property Graph database](https://github.com/falkordb/falkordb) - formerly RedisGraph
 
 # Workshops and conferences featuring the GraphBLAS (reverse chronological)
 


### PR DESCRIPTION
forGraphBLASGo is a Go binding for SuiteSparse:GraphBLAS.
FalkorDB is the new name for RedisGraph.
